### PR TITLE
Re-fix previous fix within DataTablesConfig() method

### DIFF
--- a/helpers/js/table.js
+++ b/helpers/js/table.js
@@ -93,6 +93,6 @@ window.DataTableConfig = (tableName) => {
       return cols
     })()
   }
-  if(serverSide) dtCfg.ajax = (true === dataSrc) ? window.location.href : dataSrc
+  if(serverSide) dtCfg.ajax = (undefined === dataSrc) ? window.location.href : dataSrc
   return dtCfg
 }


### PR DESCRIPTION
Broke when there is no data-src somehow?
I don't recall using `(true === dataSrc)` in the logic definitely should be `(undefined === dataSrc)`