### PR TITLE
Add GetOpt behavior: reject unparseable

### DIFF
--- a/lib/Command.js
+++ b/lib/Command.js
@@ -24,7 +24,7 @@ module.exports = class Command {
     this.name = 'command'
     this.log = null
     this.options = null
-    this.parser = require('minimist')
+    this.parser = require('./GetOpt').getInstance
     this.version = '0.0.0'
   }
   checkLog(){
@@ -64,7 +64,7 @@ module.exports = class Command {
   }
   parse(argv){
     this.checkParser()
-    const opts = this.parser(argv)
+    const opts = (this.parser(argv)).opts()
     if(opts.h || opts.help){
       return this.printHelp()
     }

--- a/lib/GetOpt.js
+++ b/lib/GetOpt.js
@@ -188,8 +188,11 @@ module.exports = class GetOpt {
     var arg = this.gop_argv[this.gop_optind]
 
     if (0 === this.gop_subind) {
-      if ('-' === arg || '' === arg || '-' !== arg[0])
-        return undefined
+      if ('-' === arg || '' === arg || '-' !== arg[0]){
+        this.gop_optind++
+        this.gop_subind = 0
+        return ({ option: false, optarg: arg })
+      }
 
       if ('--' === arg) {
         this.gop_optind++
@@ -325,9 +328,15 @@ module.exports = class GetOpt {
   opts()
   {
     let rv = {}
+    let un = []
     let arg
-    while (undefined !== (arg = this.getopt())){
+    while (this.gop_optind < this.gop_argv.length){
+      if (undefined === (arg = this.getopt())) continue
       if(arg.hasOwnProperty('option')){
+        if(false === arg.option){
+          un.push(arg.optarg)
+          continue
+        }
         let val = (arg.hasOwnProperty('optarg')) ? arg.optarg : true
         let ref
         if((ref = arg.option.charCodeAt(0)) > 255 &&
@@ -346,6 +355,7 @@ module.exports = class GetOpt {
             rv[k] = rv[arg.option]
       }
     }
+    if(0 !== un.length) rv.__ = un
     return rv
   }
 }

--- a/lib/GetOpt.js
+++ b/lib/GetOpt.js
@@ -116,6 +116,7 @@ module.exports = class GetOpt {
   {
     let rv = ''
     let marker = 0x1000
+    let _consume = false
     for(const a of argv){
       let m
       if(null !== (m = a.match(/^--([^=]*)=.*$/))){
@@ -128,7 +129,11 @@ module.exports = class GetOpt {
         this.optmap[marker] = m[1]
         marker++
       } else if(null !== (m = a.match(/^-([^-][^=]*)$/))){
+        _consume = true
         rv = rv + m[1]
+      } else if (_consume){
+        _consume = false
+        rv = rv + ':'
       }
     }
     return rv

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,11 +421,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,10 @@
   },
   "main": "./lib/Util.js",
   "scripts": {
-    "test": "node ./node_modules/mocha/bin/mocha ./test/kado.js && node ./test/TestRunner.js"
+    "test": "node ./node_modules/mocha/bin/mocha ./test/kado.js && node ./test/TestRunner.test.js && node ./test/Validate.test.js"
   },
   "dependencies": {
     "cron": "^1.7.2",
-    "minimist": "^1.2.0",
     "pretty-bytes": "^5.3.0"
   },
   "devDependencies": {

--- a/test/CommandServer.test.js
+++ b/test/CommandServer.test.js
@@ -58,6 +58,6 @@ describe('CommandServer',()=> {
     return expect.eq(await cli.run('test test -t test'),'test')
   })
   it('should run a command with a full switch',async () => {
-    return expect.eq(await cli.run('test test --test test'),'test')
+    return expect.eq(await cli.run('test test --test=test'),'test')
   })
 })

--- a/test/GetOpt.test.js
+++ b/test/GetOpt.test.js
@@ -79,7 +79,7 @@ describe('GetOpt',()=>{
     expect.eq(parser.gop_silent,true)
     expect.eqDeep(parser.gop_options,{l:true})
     expect.eqDeep(parser.gop_aliases,{long:'l'})
-    expect.eqDeep(parser.opts(),{l:['arg1','q'], long:['arg1','q']})
+    expect.eqDeep(parser.opts(),{l:['arg1','q','foo'], long:['arg1','q','foo'], __:['b']})
   })
   it('should parse optstr=\'l:(long)(longer)\' with ARGV=[]',()=>{
     parser = new GetOpt([],'l:(long)(longer)')

--- a/test/TestRunner.test.js
+++ b/test/TestRunner.test.js
@@ -1,7 +1,9 @@
 'use strict';
 const runner = require('../lib/TestRunner').getInstance('Kado')
 const { expect } = require('../lib/Validate')
+//jshint -W079
 const test = runner.suite('suite1')
+//jshint +W079
 const getOne = function(){ return new Promise((resolve)=>{
   setTimeout(()=>{ resolve(1) },5)
 }) }

--- a/test/kado.js
+++ b/test/kado.js
@@ -37,6 +37,6 @@ describe('kado',function(){
     'Router',
     'Search',
     'Util',
-    'View','Validate',
+    'View',
   ].filter(fn => (-1 < fn.search(focus)))) require('./' + test + '.test')
 })


### PR DESCRIPTION
Add GetOpt behavior: reject unparseable items in argv into `__` and fix stepping past unknown items to collect all arguments available